### PR TITLE
ISortableScope: extends ISortable

### DIFF
--- a/src/ISortableScope.php
+++ b/src/ISortableScope.php
@@ -4,7 +4,7 @@ namespace Librette\Doctrine\Sortable;
 /**
  * @author David Matejka
  */
-interface ISortableScope
+interface ISortableScope extends ISortable
 {
 
 	/**


### PR DESCRIPTION
ISortableScope extends ISortable so it can be used alone and implementing both of those interfaces is not necessary
